### PR TITLE
テスト、SentMessageエンティティのMESSAGE_IDの長さを拡張。

### DIFF
--- a/src/test/java/nablarch/test/core/messaging/MessagingRequestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/messaging/MessagingRequestTestSupportTest.java
@@ -211,7 +211,7 @@ public class MessagingRequestTestSupportTest {
         }
 
         @Id
-        @Column(name = "MESSAGE_ID", length = 64, nullable = false)
+        @Column(name = "MESSAGE_ID", length = 255, nullable = false)
         public String messageId;
 
         @Id


### PR DESCRIPTION
ActiveMQが環境情報からlocalhostの値を設定するため、その環境依存に対するテスト実行の安定化処置として実施。