### PR TITLE
JUnit4を現行バージョンにアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.13.1</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
# 概要

* 以下の修正を適用したいため、JUnit4のバージョンを上げました。
  https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later
* 依存関係の修正のみです。
* 本PRはリリース対象です。JUnit4にcompileでスコープで依存しているためです。
