### PR TITLE
HttpRequest#getContentTypeがnullを返却することに伴う修正

### DIFF
--- a/src/main/java/nablarch/fw/web/HttpServer.java
+++ b/src/main/java/nablarch/fw/web/HttpServer.java
@@ -390,8 +390,11 @@ public abstract class HttpServer extends HandlerQueueManager<HttpServer> impleme
                 );
             }
         }
-        
-        boolean isHtml = HTML_PATTERN.matcher(res.getContentType()).matches();
+        boolean isHtml = false;
+        String contentType = res.getContentType();
+        if(contentType != null){
+            isHtml = HTML_PATTERN.matcher(res.getContentType()).matches();
+        }
         
         if (!isHtml) {
             // HTML以外の場合はContent-Dispositionヘッダに指定されたファイル名の取得を試みる。
@@ -545,7 +548,11 @@ public abstract class HttpServer extends HandlerQueueManager<HttpServer> impleme
      */
     private String getHttpDumpFileName(HttpRequest req, HttpResponse res) {
         DateFormat format = new SimpleDateFormat("yyyy-MMdd-HHmmss-SSS_");
-        String extension = EXTENSION_PATTERN.matcher(res.getContentType()).replaceAll(".$1");
+        String contentType = res.getContentType();
+        String extension = "";
+        if (contentType != null) {
+            extension = EXTENSION_PATTERN.matcher(res.getContentType()).replaceAll(".$1");
+        }
         return format.format(new Date())
                 + req.getMethod()
                 + SLASH.matcher(req.getRequestUri()).replaceAll("_")


### PR DESCRIPTION
## 背景
- https://github.com/nablarch/nablarch-fw-web/pull/92 の修正に伴いHttpRequest#getContentTypeがnullを返す可能性があります。
  HttpRequest#getContentTypeがnullを返さない前提のロジックが存在するため修正が必要になります。

## 確認したこと
- https://github.com/nablarch/nablarch-testing-jetty9/pull/3 のテストが成功すること。
- https://github.com/nablarch/nablarch-testing-jetty6/pull/4 のテストが成功すること。