### PR TITLE
レスポンス出力時にContent-Type未設定を許可する件に関する対応

### DIFF
--- a/src/main/java/nablarch/fw/web/HttpServer.java
+++ b/src/main/java/nablarch/fw/web/HttpServer.java
@@ -391,7 +391,9 @@ public abstract class HttpServer extends HandlerQueueManager<HttpServer> impleme
             }
         }
         boolean isHtml = false;
-        String contentType = res.getContentType();
+        // レスポンスオブジェクトの書き換えを避けるためHttpResponse#getHeader()を使用してContent-Type"を取得する。
+        // HttpResponse#getContentType()を呼び出すと、ボディが空の場合自動的にレスポンスオブジェクトにContent-Typeを設定してしまう。
+        String contentType = res.getHeader("Content-Type");
         if(contentType != null){
             isHtml = HTML_PATTERN.matcher(res.getContentType()).matches();
         }
@@ -548,7 +550,9 @@ public abstract class HttpServer extends HandlerQueueManager<HttpServer> impleme
      */
     private String getHttpDumpFileName(HttpRequest req, HttpResponse res) {
         DateFormat format = new SimpleDateFormat("yyyy-MMdd-HHmmss-SSS_");
-        String contentType = res.getContentType();
+        // レスポンスオブジェクトの書き換えを避けるためHttpResponse#getHeader()を使用してContent-Type"を取得する。
+        // HttpResponse#getContentType()を呼び出すと、ボディが空の場合自動的にレスポンスオブジェクトにContent-Typeを設定してしまう。
+        String contentType = res.getHeader("Content-Type");
         String extension = "";
         if (contentType != null) {
             extension = EXTENSION_PATTERN.matcher(res.getContentType()).replaceAll(".$1");


### PR DESCRIPTION
## 背景
https://github.com/nablarch/nablarch-fw-web/pull/92 の対応により、レスポンス出力時にContent-Typeが未設定を許容するようになった。  
ボディが未設定の際、レスポンス書き出し前にHttpResponse#getContentType()を呼び出すとContent-Typeの設定を行わないが、レスポンス出力後にを呼び出すと、Content-Typeの自動設定を行ってしまう。

これは、レスポンス書き出し後、HttpResponse#getContentType()がボディ未設定とボディに明示的に空文字列を設定した場合の区別が付かないためである。

## 対応内容
- Content-Type取得時にHttpResponse#getHeader()を使用するように変更。このメソッドはContent-Typeの自動設定を行わない。

## 確認内容