### PR TITLE
test: リクエストパターンの不具合修正でマッチ判定の動作が変わった影響によりテストが落ちていたのを修正(v5-develop)

### DIFF
--- a/src/test/java/nablarch/fw/web/MockHttpRequestTest.java
+++ b/src/test/java/nablarch/fw/web/MockHttpRequestTest.java
@@ -385,7 +385,7 @@ public class MockHttpRequestTest {
         final List<HttpRequest> holder = new ArrayList<HttpRequest>();
 
         HttpServer server = new MockHttpServer()
-                .addHandler("//*", new HttpRequestHandler() {
+                .addHandler("//", new HttpRequestHandler() {
                     public HttpResponse handle(HttpRequest request, ExecutionContext ctx) {
                         request.getParamMap(); // リクエストスレッド内でパラメータの取得を行っておく必要がある。
                         holder.add(request);
@@ -433,7 +433,7 @@ public class MockHttpRequestTest {
         final List<HttpRequest> holder = new ArrayList<HttpRequest>();
 
         HttpServer server = new MockHttpServer()
-                .addHandler("//*", new HttpRequestHandler() {
+                .addHandler("//", new HttpRequestHandler() {
                     public HttpResponse handle(HttpRequest request, ExecutionContext ctx) {
                         request.getParamMap(); // リクエストスレッド内でパラメータの取得を行っておく必要がある。
                         holder.add(request);
@@ -471,7 +471,7 @@ public class MockHttpRequestTest {
         final List<HttpRequest> holder = new ArrayList<HttpRequest>();
 
         HttpServer server = new MockHttpServer()
-                .addHandler("//*", new HttpRequestHandler() {
+                .addHandler("//", new HttpRequestHandler() {
                     public HttpResponse handle(HttpRequest request, ExecutionContext ctx) {
                         request.getParamMap(); // リクエストスレッド内でパラメータの取得を行っておく必要がある。
                         holder.add(request);


### PR DESCRIPTION
`//*` が拡張子を含むパスにマッチしていた不具合を修正したことで、 `/index.html` などのパスにマッチしなくなり、テストが落ちていました。