### PR TITLE
Form/EntityのテストのBean Validation対応：Sonarqubeの指摘を取り込みました

### DIFF
--- a/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
+++ b/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
@@ -261,9 +261,9 @@ public class CharsetTestVariation<ENTITY> {
         if (max == Integer.MAX_VALUE) {
             return;
         }
-        Integer min = isMinEmpty ? null : this.min;
+        Integer minLocal = isMinEmpty ? null : min;
         String expectedMessageString = StringUtil.isNullOrEmpty(messageIdWhenInvalidLength)
-                ? EntityTestConfiguration.getConfig().getOverLimitMessageId(max, min) // デフォルトのメッセージを出力
+                ? EntityTestConfiguration.getConfig().getOverLimitMessageId(max, minLocal) // デフォルトのメッセージを出力
                 : messageIdWhenInvalidLength;                                         // テストケースで明示的に指定したメッセージを出力
         testValidationWithValidCharset(max + 1, expectedMessageString, "over limit length test.");
     }

--- a/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
+++ b/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
@@ -275,7 +275,7 @@ public class CharsetTestVariation<ENTITY> {
         if (min <= 1) {
             return;
         }
-        Integer maxLocal = isMaxEmpty ? null : this.max;
+        Integer maxLocal = isMaxEmpty ? null : max;
         String expectedMessageString = StringUtil.isNullOrEmpty(messageIdWhenInvalidLength)
                 ? EntityTestConfiguration.getConfig().getUnderLimitMessageId(maxLocal, min) // デフォルトのメッセージを出力
                 : messageIdWhenInvalidLength;                                          // テストケースで明示的に指定したメッセージを出力

--- a/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
+++ b/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
@@ -54,7 +54,7 @@ public class CharsetTestVariation<ENTITY> {
         COLUMNS_EXCEPT_CHARSET.add(MESSAGE_ID_WHEN_EMPTY_INPUT);
         COLUMNS_EXCEPT_CHARSET.add(INTERPOLATE_KEY_PREFIX);
         COLUMNS_EXCEPT_CHARSET.add(INTERPOLATE_VALUE_PREFIX);
-    };
+    }
 
 
     /** OKマーク */

--- a/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
+++ b/src/main/java/nablarch/test/core/entity/CharsetTestVariation.java
@@ -46,13 +46,15 @@ public class CharsetTestVariation<ENTITY> {
             MIN
     );
 
-    private static final List<String> COLUMNS_EXCEPT_CHARSET = new ArrayList<String>(){{
-        addAll(REQUIRED_COLUMNS);
-        add(MESSAGE_ID_WHEN_INVALID_LENGTH);
-        add(MESSAGE_ID_WHEN_EMPTY_INPUT);
-        add(INTERPOLATE_KEY_PREFIX);
-        add(INTERPOLATE_VALUE_PREFIX);
-    }};
+    /** 文字種以外のカラム */
+    private static final List<String> COLUMNS_EXCEPT_CHARSET = new ArrayList<String>();
+    static {
+        COLUMNS_EXCEPT_CHARSET.addAll(REQUIRED_COLUMNS);
+        COLUMNS_EXCEPT_CHARSET.add(MESSAGE_ID_WHEN_INVALID_LENGTH);
+        COLUMNS_EXCEPT_CHARSET.add(MESSAGE_ID_WHEN_EMPTY_INPUT);
+        COLUMNS_EXCEPT_CHARSET.add(INTERPOLATE_KEY_PREFIX);
+        COLUMNS_EXCEPT_CHARSET.add(INTERPOLATE_VALUE_PREFIX);
+    };
 
 
     /** OKマーク */
@@ -273,20 +275,21 @@ public class CharsetTestVariation<ENTITY> {
         if (min <= 1) {
             return;
         }
-        Integer max = isMaxEmpty ? null : this.max;
+        Integer maxLocal = isMaxEmpty ? null : this.max;
         String expectedMessageString = StringUtil.isNullOrEmpty(messageIdWhenInvalidLength)
-                ? EntityTestConfiguration.getConfig().getUnderLimitMessageId(max, min) // デフォルトのメッセージを出力
+                ? EntityTestConfiguration.getConfig().getUnderLimitMessageId(maxLocal, min) // デフォルトのメッセージを出力
                 : messageIdWhenInvalidLength;                                          // テストケースで明示的に指定したメッセージを出力
         testValidationWithValidCharset(min - 1, expectedMessageString, "under limit length test.");
     }
 
     /** 未入力のテストを行う。 */
     public void testEmptyInput() {
-        String expectedMessageString = (isEmptyAllowed)
-                ? ""                                      // 必須項目でない場合（メッセージが出ないこと）
-                : StringUtil.isNullOrEmpty(messageIdWhenEmptyInput)            // 必須項目の場合、メッセージを出力する。
+        String expectedRequiredMessage = StringUtil.isNullOrEmpty(messageIdWhenEmptyInput)
                 ? EntityTestConfiguration.getConfig().getEmptyInputMessageId() // デフォルトのメッセージを出力
                 : messageIdWhenEmptyInput;                                     // テストケースで明示的に指定したメッセージを出力
+        String expectedMessageString = (isEmptyAllowed)
+                ? ""                                      // 必須項目でない場合（メッセージが出ないこと）
+                : expectedRequiredMessage;                // 必須項目の場合（メッセージが出力されること）
         testValidationWithValidCharset(0, expectedMessageString, "empty input test.");
     }
 

--- a/src/main/java/nablarch/test/core/entity/MockMessageInterpolatorContext.java
+++ b/src/main/java/nablarch/test/core/entity/MockMessageInterpolatorContext.java
@@ -37,12 +37,12 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
     @Override
     public Object getValidatedValue() {
-        throw new UnsupportedOperationException("No use of this method is intended.");
+        throw new UnsupportedOperationException("Unsupported method was called.");
     }
 
     @Override
     public <T> T unwrap(Class<T> type) {
-        throw new UnsupportedOperationException("No use of this method is intended.");
+        throw new UnsupportedOperationException("Unsupported method was called.");
     }
 
     /**
@@ -68,32 +68,32 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
         @Override
         public T getAnnotation() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public String getMessageTemplate() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public Set<Class<?>> getGroups() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public Set<Class<? extends Payload>> getPayload() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public ConstraintTarget getValidationAppliesTo() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public List<Class<? extends ConstraintValidator<T, ?>>> getConstraintValidatorClasses() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
@@ -103,12 +103,12 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
         @Override
         public Set<ConstraintDescriptor<?>> getComposingConstraints() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
 
         @Override
         public boolean isReportAsSingleViolation() {
-            throw new UnsupportedOperationException("No use of this method is intended.");
+            throw new UnsupportedOperationException("Unsupported method was called.");
         }
     }
 }

--- a/src/main/java/nablarch/test/core/entity/MockMessageInterpolatorContext.java
+++ b/src/main/java/nablarch/test/core/entity/MockMessageInterpolatorContext.java
@@ -22,6 +22,11 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
     private final ConstraintDescriptor<?> constraintDescriptor;
 
     /**
+     * サポート外メソッドを呼び出したときのエラーメッセージ。
+     */
+    private static final String UNSUPPORTED_METHOD_WAS_CALLED = "Unsupported method was called.";
+
+    /**
      * コンストラクタ。
      *
      * @param interpolationMap 補完用属性のマップ
@@ -37,12 +42,12 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
     @Override
     public Object getValidatedValue() {
-        throw new UnsupportedOperationException("Unsupported method was called.");
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
     }
 
     @Override
     public <T> T unwrap(Class<T> type) {
-        throw new UnsupportedOperationException("Unsupported method was called.");
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
     }
 
     /**
@@ -68,32 +73,32 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
         @Override
         public T getAnnotation() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public String getMessageTemplate() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public Set<Class<?>> getGroups() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public Set<Class<? extends Payload>> getPayload() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public ConstraintTarget getValidationAppliesTo() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public List<Class<? extends ConstraintValidator<T, ?>>> getConstraintValidatorClasses() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
@@ -103,12 +108,12 @@ public class MockMessageInterpolatorContext implements MessageInterpolator.Conte
 
         @Override
         public Set<ConstraintDescriptor<?>> getComposingConstraints() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
 
         @Override
         public boolean isReportAsSingleViolation() {
-            throw new UnsupportedOperationException("Unsupported method was called.");
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD_WAS_CALLED);
         }
     }
 }

--- a/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
+++ b/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
@@ -14,6 +14,8 @@ public class MockMessageInterpolatorContextTest {
 
     private final MockMessageInterpolatorContext sut = new MockMessageInterpolatorContext(new HashMap<String, Object>());
 
+    private static final String EXPECTED_MSG = "Unsupported method was called.";
+
     /**
      * {@link UnsupportedOperationException}が送出されることを確認する。
      */
@@ -21,7 +23,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetValidatedValue(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getValidatedValue();
     }
@@ -33,7 +35,7 @@ public class MockMessageInterpolatorContextTest {
     public void testUnwrap(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.unwrap(this.getClass());
     }
@@ -45,7 +47,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetAnnotation(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getAnnotation();
     }
@@ -57,7 +59,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetMessageTemplate(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getMessageTemplate();
     }
@@ -69,7 +71,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetGroup(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getGroups();
     }
@@ -81,7 +83,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetPayload(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getPayload();
     }
@@ -93,7 +95,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetValidationAppliesTo(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getValidationAppliesTo();
     }
@@ -105,7 +107,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetConstraintValidatorClasses(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getConstraintValidatorClasses();
     }
@@ -117,7 +119,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetComposingConstraints(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().getComposingConstraints();
     }
@@ -129,7 +131,7 @@ public class MockMessageInterpolatorContextTest {
     public void testIsReportAsSingleViolation(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Unsupported method was called.");
+        expectedException.expectMessage(EXPECTED_MSG);
 
         sut.getConstraintDescriptor().isReportAsSingleViolation();
     }

--- a/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
+++ b/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
@@ -21,7 +21,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetValidatedValue(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getValidatedValue();
     }
@@ -33,7 +33,7 @@ public class MockMessageInterpolatorContextTest {
     public void testUnwrap(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.unwrap(this.getClass());
     }
@@ -45,7 +45,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetAnnotation(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getAnnotation();
     }
@@ -57,7 +57,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetMessageTemplate(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getMessageTemplate();
     }
@@ -69,7 +69,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetGroup(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getGroups();
     }
@@ -81,7 +81,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetPayload(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getPayload();
     }
@@ -93,7 +93,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetValidationAppliesTo(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getValidationAppliesTo();
     }
@@ -105,7 +105,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetConstraintValidatorClasses(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getConstraintValidatorClasses();
     }
@@ -117,7 +117,7 @@ public class MockMessageInterpolatorContextTest {
     public void testGetComposingConstraints(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().getComposingConstraints();
     }
@@ -129,7 +129,7 @@ public class MockMessageInterpolatorContextTest {
     public void testIsReportAsSingleViolation(){
 
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("No use of this method is intended.");
+        expectedException.expectMessage("Unsupported method was called.");
 
         sut.getConstraintDescriptor().isReportAsSingleViolation();
     }

--- a/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
+++ b/src/test/java/nablarch/test/core/entity/MockMessageInterpolatorContextTest.java
@@ -1,0 +1,136 @@
+package nablarch.test.core.entity;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+
+public class MockMessageInterpolatorContextTest {
+
+    @SuppressWarnings("deprecation")
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final MockMessageInterpolatorContext sut = new MockMessageInterpolatorContext(new HashMap<String, Object>());
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetValidatedValue(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getValidatedValue();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testUnwrap(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.unwrap(this.getClass());
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetAnnotation(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getAnnotation();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetMessageTemplate(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getMessageTemplate();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetGroup(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getGroups();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetPayload(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getPayload();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetValidationAppliesTo(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getValidationAppliesTo();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetConstraintValidatorClasses(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getConstraintValidatorClasses();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testGetComposingConstraints(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().getComposingConstraints();
+    }
+
+    /**
+     * {@link UnsupportedOperationException}が送出されることを確認する。
+     */
+    @Test
+    public void testIsReportAsSingleViolation(){
+
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("No use of this method is intended.");
+
+        sut.getConstraintDescriptor().isReportAsSingleViolation();
+    }
+}


### PR DESCRIPTION
- 今回修正したコードのうち、Major以上の指摘箇所について修正しました。
    - CharacterTestVariationのCOLUMNS_EXCEPT_CHARSETについて、値の設定をstaticイニシャライザで実施
    - ローカル変数の名前を変更
    - ネストした三項演算子を分割
- 今回修正したコードのうち、カバレッジ網羅できていなかった箇所のテストを追加しました。
    - MockMessageInterpolatorContextのサポートしていないメソッドについて、例外出力されるテストを追加