### PR TITLE
NTF/HTTPテストでHTTPメソッド指定可能にする対応で、インスペクションの警告を修正

### DIFF
--- a/src/main/java/nablarch/test/core/http/AbstractHttpRequestTestTemplate.java
+++ b/src/main/java/nablarch/test/core/http/AbstractHttpRequestTestTemplate.java
@@ -275,7 +275,8 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
      * テストで使用するデータのキャッシュをクリアする
      * @param testCaseInfo テストケース情報
      */
-    protected void clearPreviousTestData(@SuppressWarnings("unused") INF testCaseInfo) {
+    @SuppressWarnings("unused")
+    protected void clearPreviousTestData(INF testCaseInfo) {
 
         // メッセージ同期送信を行う場合に、MockMessagingContextに必要なテストケースの情報を格納する
         RequestTestingMessagingClient.clearSendingMessageCache();

--- a/src/main/java/nablarch/test/core/http/AbstractHttpRequestTestTemplate.java
+++ b/src/main/java/nablarch/test/core/http/AbstractHttpRequestTestTemplate.java
@@ -4,7 +4,7 @@ import static nablarch.core.util.Builder.concat;
 import static nablarch.test.Assertion.assertEqualsAsString;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,18 +77,16 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
     private static final String EXPECTED_RESPONSE_LIST_MAP = "responseResult";
 
     /** Assert対象から除外するカラム */
-    private static final List<String> ASSERT_SKIP_EXPECTED_COLUMNS = Arrays.asList("no");
+    private static final List<String> ASSERT_SKIP_EXPECTED_COLUMNS = Collections.singletonList("no");
 
     /** LIST_MAPキャッシュ */
-    private Map<String, List<Map<String, String>>> listMapCache = new HashMap<String, List<Map<String, String>>>();
+    private final Map<String, List<Map<String, String>>> listMapCache = new HashMap<String, List<Map<String, String>>>();
 
     /** 何も行わない{@link Advice}実装。 */
     private final Advice<INF> nopAdvice = new Advice<INF>() {
-        /** {@inheritDoc} */
         public void afterExecute(INF testCaseInfo, ExecutionContext context) {
         }
 
-        /** {@inheritDoc} */
         public void beforeExecute(INF testCaseInfo, ExecutionContext context) {
         }
     };
@@ -277,7 +275,7 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
      * テストで使用するデータのキャッシュをクリアする
      * @param testCaseInfo テストケース情報
      */
-    protected void clearPreviousTestData(INF testCaseInfo) {
+    protected void clearPreviousTestData(@SuppressWarnings("unused") INF testCaseInfo) {
 
         // メッセージ同期送信を行う場合に、MockMessagingContextに必要なテストケースの情報を格納する
         RequestTestingMessagingClient.clearSendingMessageCache();
@@ -479,7 +477,7 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
      */
     protected void assertResponse(INF testCaseInfo, HttpResponse response) {
         String message  = testCaseInfo.getTestCaseName() + "[HTTP STATUS]";
-        assertStatusCode(message, Integer.valueOf(testCaseInfo.getExpectedStatusCode()),  response);
+        assertStatusCode(message, Integer.parseInt(testCaseInfo.getExpectedStatusCode()),  response);
     }
 
     /**
@@ -636,8 +634,7 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
                     String prefix = assertKey.substring(0, prefixLength);
                     String key = assertKey.substring(prefixLength + 1);
                     if (context.getRequestScopeMap().containsKey(prefix)) {
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> varMap = (Map<String, Object>) context.getRequestScopedVar(prefix);
+                        Map<String, Object> varMap = context.getRequestScopedVar(prefix);
                         Object actValue = varMap.get(key);
                         if (actValue != null) {
                             if (actValue.getClass().isArray()) {
@@ -674,7 +671,7 @@ public abstract class AbstractHttpRequestTestTemplate<INF extends TestCaseInfo> 
             return;
         }
         String key = testCaseInfo.getSearchResultKey();
-        SqlResultSet actual = (SqlResultSet) context.getRequestScopedVar(key);
+        SqlResultSet actual = context.getRequestScopedVar(key);
         assertSqlResultSetEquals(testCaseInfo.getTestCaseName(), testCaseInfo.getSheetName(),
                                  testCaseInfo.getExpectedSearchId(), actual);
 

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -321,22 +321,19 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param config HttpTestConfiguration
      * @return HTTPサーバ
      */
-    @SuppressWarnings("UnusedReturnValue")
+    @SuppressWarnings({"UnusedReturnValue", "AssignmentToStaticFieldFromInstanceMethod", "rawtypes"})
     protected HttpServer createHttpServer(HttpTestConfiguration config) {
         // HTTPサーバ生成
-        //noinspection AssignmentToStaticFieldFromInstanceMethod
         server = createHttpServer();
         // HttpTestConfigurationの値を設定する
         server.setTempDirectory(config.getTempDirectory());
         server.setWarBasePaths(getWarBasePaths(config));
         // サーバ起動
         server.startLocal();
-        //noinspection AssignmentToStaticFieldFromInstanceMethod
         handler = new HttpRequestTestSupportHandler(config);
 
         // ハンドラキューの準備
         WebFrontController controller = SystemRepository.get("webFrontController");
-        //noinspection rawtypes
         List<Handler> handlerQueue = controller.getHandlerQueue();
         prepareHandlerQueue(handlerQueue);
         server.setHandlerQueue(handlerQueue);

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -49,7 +49,6 @@ import nablarch.fw.web.HttpServerFactory;
 import nablarch.fw.web.MockHttpCookie;
 import nablarch.fw.web.MockHttpRequest;
 import nablarch.fw.web.ResourceLocator;
-import nablarch.fw.web.handler.SessionConcurrentAccessHandler;
 import nablarch.fw.web.servlet.WebFrontController;
 import nablarch.fw.web.upload.PartInfo;
 import nablarch.fw.web.upload.PartInfoHolder;
@@ -60,7 +59,6 @@ import nablarch.test.TestSupport;
 import nablarch.test.core.db.DbAccessTestSupport;
 import nablarch.test.core.db.EntityTestSupport;
 import nablarch.test.core.util.FileUtils;
-import nablarch.test.core.util.ListWrapper;
 import nablarch.test.event.TestEventDispatcher;
 import nablarch.test.tool.htmlcheck.HtmlChecker;
 

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -489,7 +489,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param dumpDir        出力先ディレクトリ
      * @param warBaseLocator warベースのリソースロケータ
      */
-    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
+    @SuppressWarnings({"AssignmentToStaticFieldFromInstanceMethod", "ResultOfMethodCallIgnored"})
     protected void rewriteResourceFile(HttpTestConfiguration config, File dumpDir, ResourceLocator warBaseLocator) {
 
         if (null == jsTestResourcePath) {
@@ -541,7 +541,6 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
                 FileUtil.closeQuietly(reader, writer);
             }
             // 出力したファイルのタイムスタンプに出力元ファイルのタイムスタンプを設定する。
-            //noinspection ResultOfMethodCallIgnored
             outputFile.setLastModified(file.lastModified());
         }
     }

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -80,7 +80,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     private static final Pattern HTML_TYPE = Pattern.compile("[^/]*/html?.*");
 
     /** ファイルセパレータ */
-    private static char fileSeparator = File.separatorChar;
+    private static final char fileSeparator = File.separatorChar;
 
     /** HttpServer */
     private static HttpServer server;
@@ -101,7 +101,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     private final DbAccessTestSupport dbSupport;
 
     /** 静的ファイルコピー時に内容を置き換える対象のファイルリスト */
-    private List<File> replaceFiles = new ArrayList<File>();
+    private final List<File> replaceFiles = new ArrayList<File>();
 
     /** 初期化完了フラグ。 */
     private static boolean initialized;
@@ -167,7 +167,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param dumpDir   ダンプディレクトリ
      * @param className クラス名
      */
-    private void initialize(HttpTestConfiguration config, File dumpDir, String className) {
+    private void initialize(HttpTestConfiguration config, @SuppressWarnings("unused") File dumpDir, String className) {
 
         if (config.isBackup()) {
             backupDumpFile(config);
@@ -177,6 +177,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
 
         // 内蔵サーバ生成
         createHttpServer(config);
+        //noinspection AssignmentToStaticFieldFromInstanceMethod
         initialized = true;
     }
 
@@ -319,18 +320,22 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param config HttpTestConfiguration
      * @return HTTPサーバ
      */
+    @SuppressWarnings("UnusedReturnValue")
     protected HttpServer createHttpServer(HttpTestConfiguration config) {
         // HTTPサーバ生成
+        //noinspection AssignmentToStaticFieldFromInstanceMethod
         server = createHttpServer();
         // HttpTestConfigurationの値を設定する
         server.setTempDirectory(config.getTempDirectory());
         server.setWarBasePaths(getWarBasePaths(config));
         // サーバ起動
         server.startLocal();
+        //noinspection AssignmentToStaticFieldFromInstanceMethod
         handler = new HttpRequestTestSupportHandler(config);
 
         // ハンドラキューの準備
         WebFrontController controller = SystemRepository.get("webFrontController");
+        //noinspection rawtypes
         List<Handler> handlerQueue = controller.getHandlerQueue();
         prepareHandlerQueue(handlerQueue);
         server.setHandlerQueue(handlerQueue);
@@ -354,9 +359,8 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     protected void prepareHandlerQueue(List<Handler> handlerQueue) {
 
         // セッションアクセスハンドラの準備
-        SessionConcurrentAccessHandler sessionHandler
-                = ListWrapper.wrap(handlerQueue)
-                             .select(SessionConcurrentAccessHandler.class);
+        //noinspection deprecation
+        ListWrapper.wrap(handlerQueue).select(SessionConcurrentAccessHandler.class);
 
         // リクエスト単体テストに必要なハンドラをハンドラキューに挿入
         servletForwardVerifier.register(handlerQueue);
@@ -485,6 +489,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     /**
      * HTMLリソースディレクトリ内のCSSファイルを置換する。
      *
+     * <p>
      * 出力したCSSファイルのタイムスタンプには、出力元CSSファイルのタイムスタンプを設定する。
      * 次回、出力時にはタイムスタンプに変更がない限り、出力は行わない。
      *
@@ -495,6 +500,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     protected void rewriteResourceFile(HttpTestConfiguration config, File dumpDir, ResourceLocator warBaseLocator) {
 
         if (null == jsTestResourcePath) {
+            //noinspection AssignmentToStaticFieldFromInstanceMethod
             jsTestResourcePath = new File(config.getJsTestResourceDir()).getAbsolutePath();
         }
         String realPath = warBaseLocator.getRealPath();
@@ -543,6 +549,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
                 FileUtil.closeQuietly(reader, writer);
             }
             // 出力したファイルのタイムスタンプに出力元ファイルのタイムスタンプを設定する。
+            //noinspection ResultOfMethodCallIgnored
             outputFile.setLastModified(file.lastModified());
         }
     }
@@ -639,7 +646,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     protected class HtmlResourceExtensionFilter implements FileFilter {
 
         /** HttpTestConfiguration */
-        private HttpTestConfiguration configuration = null;
+        private final HttpTestConfiguration configuration;
 
         /**
          * コンストラクタ。
@@ -710,11 +717,14 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     
     /**
      * ステータスコードが想定通りであることを表明する。<br/>
+     *
+     * <p>
      * 内蔵サーバから戻り値で返却されたHTTPレスポンスがリダイレクトである場合、
      * ステータスコードが303または302であることを表明する。
      * このとき、内蔵サーバから返却されるHTTPレスポンスと比較しないのは、後方互換性を保つためである。
      * （内蔵サーバは、リダイレクト時のステータスコードに'302 FOUND'を使用する）
      *
+     * <p>
      * 上記以外の場合は、{@link HttpRequestTestSupportHandler#getStatusCode()}
      * のステータスコードを比較対象とする。
      *
@@ -751,6 +761,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param statusCode ステータスコード
      * @return ステータスコードがリダイレクトであればtrue。
      */
+    @SuppressWarnings("unused")
     private boolean isRedirected(int statusCode) {
         return 302 == statusCode || 303 == statusCode;
     }
@@ -761,6 +772,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param expectedCommaSeparated 期待するメッセージID（カンマ区切り）
      * @param actual                 実行結果(メッセージIDをリクエストスコープにもつExecutionContext)
      */
+    @SuppressWarnings("unused")
     public void assertApplicationMessageId(String expectedCommaSeparated, ExecutionContext actual) {
         assertApplicationMessageId("", expectedCommaSeparated, actual);
     }
@@ -807,6 +819,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param expected 期待するメッセージIDの配列
      * @param actual   実行結果(メッセージIDをリクエストスコープにもつExecutionContext)
      */
+    @SuppressWarnings("unused")
     public void assertApplicationMessageId(String[] expected, ExecutionContext actual) {
         assertApplicationMessageId("", expected, actual);
     }
@@ -871,6 +884,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
         }
         if (target.isDirectory()) {
             File[] files = target.listFiles();
+            assert files != null;
             for (File file : files) {
                 if (file.isDirectory()) {
                     deleteBackupFile(file);
@@ -974,7 +988,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
             if (!attachedFileNames.isEmpty()) {
                 // 添付ファイルのHTTPパラメータを書き換え
                 // key = inputタグのname属性、value = アップロードされたファイル名)
-                String[] array = attachedFileNames.toArray(new String[attachedFileNames.size()]);
+                String[] array = attachedFileNames.toArray(new String[0]);
                 params.put(name, array);
             }
         }
@@ -1219,6 +1233,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param id        シート内のデータを特定するためのID
      * @param actual    実際の値
      */
+    @SuppressWarnings("unused")
     public void assertSqlRowEquals(String message, String sheetName, String id, SqlRow actual) {
         dbSupport.assertSqlRowEquals(message, sheetName, id, actual);
     }
@@ -1243,6 +1258,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @return List-Map<String, String[]>形式のデータ
      * @see nablarch.test.core.db.DbAccessTestSupport#getListParamMap(String, String)
      */
+    @SuppressWarnings("unused")
     public List<Map<String, String[]>> getListParamMap(String sheetName, String id) {
         return dbSupport.getListParamMap(sheetName, id);
     }
@@ -1255,6 +1271,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @return Map<String,String[]>形式のデータ
      * @see nablarch.test.core.db.DbAccessTestSupport#getParamMap(String, String)
      */
+    @SuppressWarnings("unused")
     public Map<String, String[]> getParamMap(String sheetName, String id) {
         return dbSupport.getParamMap(sheetName, id);
     }
@@ -1265,6 +1282,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param sheetName 期待値を格納したシート名
      * @see nablarch.test.core.db.DbAccessTestSupport#assertTableEquals(String)
      */
+    @SuppressWarnings("unused")
     public void assertTableEquals(String sheetName) {
         dbSupport.assertTableEquals(sheetName);
     }
@@ -1276,6 +1294,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param groupId   グループID（オプション）
      * @see nablarch.test.core.db.DbAccessTestSupport#assertTableEquals(String, String)
      */
+    @SuppressWarnings("unused")
     public void assertTableEquals(String sheetName, String groupId) {
         dbSupport.assertTableEquals(sheetName, groupId);
     }
@@ -1299,6 +1318,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param id        ケース表のID(LIST_MAP=testの場合は、testを指定する。)
      * @param actual    実行結果のオブジェクト(Java Beansオブジェクト)
      */
+    @SuppressWarnings("unused")
     public void assertEntity(String sheetName, String id, Object actual) {
         EntityTestSupport entityTestSupport = new EntityTestSupport(testClass);
         entityTestSupport.assertGetterMethod(sheetName, id, actual);
@@ -1313,6 +1333,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param id        ケース表のID(LIST_MAP=testの場合は、testを指定する。)
      * @param actual    実際の値
      */
+    @SuppressWarnings("unused")
     public void assertObjectPropertyEquals(String message, String sheetName, String id, Object actual) {
         List<Map<String, String>> list = getListMap(sheetName, id);
         if (null == list || list.isEmpty()) {
@@ -1342,6 +1363,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
             Assertion.failComparing(message + "; target size does not match; ", list.size(), null);
         }
 
+        assert actual != null;
         if (actual.length != list.size()) {
             Assertion.failComparing(message + "; target size does not match; ", list.size(), actual.length);
         }
@@ -1361,6 +1383,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param id        ケース表のID(LIST_MAP=testの場合は、testを指定する。)
      * @param actual    実際の値
      */
+    @SuppressWarnings("unused")
     public void assertObjectListPropertyEquals(String message, String sheetName, String id, List<?> actual) {
         Object[] array = null == actual ? null : actual.toArray();
         assertObjectArrayPropertyEquals(message, sheetName, id, array);

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -167,7 +167,7 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param dumpDir   ダンプディレクトリ
      * @param className クラス名
      */
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "AssignmentToStaticFieldFromInstanceMethod"})
     private void initialize(HttpTestConfiguration config, File dumpDir, String className) {
 
         if (config.isBackup()) {
@@ -178,7 +178,6 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
 
         // 内蔵サーバ生成
         createHttpServer(config);
-        //noinspection AssignmentToStaticFieldFromInstanceMethod
         initialized = true;
     }
 

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -754,17 +754,6 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
     }
 
     /**
-     * ステータスコードがリダイレクト(302 or 303)であるかどうか判定する。
-     * 
-     * @param statusCode ステータスコード
-     * @return ステータスコードがリダイレクトであればtrue。
-     */
-    @SuppressWarnings("unused")
-    private boolean isRedirected(int statusCode) {
-        return 302 == statusCode || 303 == statusCode;
-    }
-
-    /**
      * メッセージIDのアサートを行う。<br>
      *
      * @param expectedCommaSeparated 期待するメッセージID（カンマ区切り）

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -489,10 +489,10 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param dumpDir        出力先ディレクトリ
      * @param warBaseLocator warベースのリソースロケータ
      */
+    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
     protected void rewriteResourceFile(HttpTestConfiguration config, File dumpDir, ResourceLocator warBaseLocator) {
 
         if (null == jsTestResourcePath) {
-            //noinspection AssignmentToStaticFieldFromInstanceMethod
             jsTestResourcePath = new File(config.getJsTestResourceDir()).getAbsolutePath();
         }
         String realPath = warBaseLocator.getRealPath();

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -354,11 +354,6 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      */
     @SuppressWarnings("rawtypes")
     protected void prepareHandlerQueue(List<Handler> handlerQueue) {
-
-        // セッションアクセスハンドラの準備
-        //noinspection deprecation
-        ListWrapper.wrap(handlerQueue).select(SessionConcurrentAccessHandler.class);
-
         // リクエスト単体テストに必要なハンドラをハンドラキューに挿入
         servletForwardVerifier.register(handlerQueue);
         handler.register(handlerQueue);

--- a/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
@@ -167,7 +167,8 @@ public class HttpRequestTestSupport extends TestEventDispatcher {
      * @param dumpDir   ダンプディレクトリ
      * @param className クラス名
      */
-    private void initialize(HttpTestConfiguration config, @SuppressWarnings("unused") File dumpDir, String className) {
+    @SuppressWarnings("unused")
+    private void initialize(HttpTestConfiguration config, File dumpDir, String className) {
 
         if (config.isBackup()) {
             backupDumpFile(config);

--- a/src/main/java/nablarch/test/core/http/TestCaseInfo.java
+++ b/src/main/java/nablarch/test/core/http/TestCaseInfo.java
@@ -84,19 +84,19 @@ public class TestCaseInfo {
     protected static final String EXPECTED_CONTENT_FILENAME = "expectedContentFileName";
 
     /** シート名 */
-    private String sheetName;
+    private final String sheetName;
     /** テストケース毎のパラメータ */
-    private Map<String, String> testCaseParams;
+    private final Map<String, String> testCaseParams;
     /** コンテキスト */
-    private List<Map<String, String>> context;
+    private final List<Map<String, String>> context;
     /** リクエスト */
-    private List<Map<String, String>> request;
+    private final List<Map<String, String>> request;
     /** 期待するレスポンスのパラメータ */
-    private List<Map<String, String>> expectedResponseParams;
+    private final List<Map<String, String>> expectedResponseParams;
     /** Cookie情報 */
-    private List<Map<String, String>> cookie;
+    private final List<Map<String, String>> cookie;
     /** クエリパラメータ情報 */
-    private List<Map<String, String>> queryParams;
+    private final List<Map<String, String>> queryParams;
 
     /** リクエストスコープ値アサートを行うか？（各テストケースで個別検証する場合にfalseを設定） */
     private boolean isAssertRequestScopeVar = true;
@@ -119,6 +119,7 @@ public class TestCaseInfo {
      * リクエストスコープ内に格納された検索結果を取得するためのキーを設定する。
      * @param searchResultKey キー
      */
+    @SuppressWarnings("unused")
     public void setSearchResultKey(String searchResultKey) {
         this.searchResultKey = searchResultKey;
     }
@@ -198,7 +199,7 @@ public class TestCaseInfo {
      * @return リクエストスコープに設定されるはずの期待値
      */
     public Map<String, String> getExpectedRequestScopeVar() {
-        return expectedResponseParams.get(Integer.valueOf(getTestCaseNo()) - 1);
+        return expectedResponseParams.get(Integer.parseInt(getTestCaseNo()) - 1);
     }
 
     /**
@@ -340,7 +341,7 @@ public class TestCaseInfo {
      */
     public Map<String, String> getRequestParameters() {
 
-        int caseNo = Integer.valueOf(getTestCaseNo());
+        int caseNo = Integer.parseInt(getTestCaseNo());
         if (request.size() < caseNo) {
             throw new IllegalArgumentException(Builder.concat(
                     "Request parameter is not defined or request parameter list size is invalid.",
@@ -355,6 +356,7 @@ public class TestCaseInfo {
      *
      * @return boolean
      */
+    @SuppressWarnings("unused")
     public boolean isRequestParametersSet() {
         return !request.isEmpty();
     }

--- a/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
+++ b/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
@@ -75,11 +75,10 @@ public class AbstractHttpRequestTestTemplateTest {
     private static final File workDir = new File("work");
 
     /** アップロード先ディレクトリの準備 */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @BeforeClass
     public static void prepareUploadDir() {
-        //noinspection ResultOfMethodCallIgnored
         workDir.delete();
-        //noinspection ResultOfMethodCallIgnored
         workDir.mkdir();
     }
 

--- a/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
+++ b/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
@@ -1,12 +1,13 @@
 package nablarch.test.core.http;
 
 import static nablarch.test.Assertion.fail;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -71,12 +72,14 @@ public class AbstractHttpRequestTestTemplateTest {
             "nablarch/test/core/http/http-test-configuration.xml");
 
     /** アップロード先ディレクトリ */
-    private static File workDir = new File("work");
+    private static final File workDir = new File("work");
 
     /** アップロード先ディレクトリの準備 */
     @BeforeClass
     public static void prepareUploadDir() {
+        //noinspection ResultOfMethodCallIgnored
         workDir.delete();
+        //noinspection ResultOfMethodCallIgnored
         workDir.mkdir();
     }
 
@@ -86,6 +89,7 @@ public class AbstractHttpRequestTestTemplateTest {
      */
     @AfterClass
     public static void deleteUploadDir() {
+        //noinspection ResultOfMethodCallIgnored
         workDir.delete();
         HttpRequestTestSupport.resetHttpServer();
     }
@@ -838,7 +842,7 @@ public class AbstractHttpRequestTestTemplateTest {
             @Override
             public HttpResponse handle(HttpRequest req, ExecutionContext ctx) {
 
-                /** 全件検索を行う */
+                // 全件検索を行う
                 SqlResultSet rs = new SimpleDbTransactionExecutor<SqlResultSet>(getManager()) {
                     @Override
                     public SqlResultSet execute(AppDbConnection connection) {
@@ -907,8 +911,6 @@ public class AbstractHttpRequestTestTemplateTest {
         public SearchResultAssertTest() {
         }
 
-        ;
-
         public SearchResultAssertTest(String pkCol1) {
             this.pkCol1 = pkCol1;
         }
@@ -924,8 +926,6 @@ public class AbstractHttpRequestTestTemplateTest {
 
         public CrlfTest() {
         }
-
-        ;
 
         public CrlfTest(String pkCol1, String col2) {
             this.pkCol1 = pkCol1;

--- a/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
+++ b/src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
@@ -86,9 +86,9 @@ public class AbstractHttpRequestTestTemplateTest {
      * アップロード先ディレクトリの削除 
      * HttpRequestTestSupportをデフォルトに復元する
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @AfterClass
     public static void deleteUploadDir() {
-        //noinspection ResultOfMethodCallIgnored
         workDir.delete();
         HttpRequestTestSupport.resetHttpServer();
     }

--- a/src/test/java/nablarch/test/core/http/HttpRequestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/HttpRequestTestSupportTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("NonAsciiCharacters")
 public class HttpRequestTestSupportTest {
 
     HttpRequestTestSupport sut = new HttpRequestTestSupport();

--- a/src/test/java/nablarch/test/core/http/TestCaseInfoTest.java
+++ b/src/test/java/nablarch/test/core/http/TestCaseInfoTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@SuppressWarnings("NonAsciiCharacters")
 public class TestCaseInfoTest {
 
     @Test


### PR DESCRIPTION
- 全体的に存在しているもの
    - 変更がないフィールドにfinalを付与
    - 不要なinheritDocを削除
    - 使用していないメソッド引数の警告をサプレス
    - Integer.valueOf⇒Integer.parseIntに変更
    - 不要なキャストを削除
    - 戻り値を使用していないメソッドの警告をサプレス
    - 使用していないメソッドの警告をサプレス
    - Javadocの修正
    - nullになり得る箇所にassertを挿入
    - テストメソッドにASCII文字以外を利用している警告をサプレス

- src/main/java/nablarch/test/core/http/AbstractHttpRequestTestTemplate.java
    - [単一要素のリストの生成にはCollections.singletonListを使用](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-5bfe4096776fb338a4e1c5bf74491ff85b20d3ff56244d18d9332bdc0db73f39R80)

- src/main/java/nablarch/test/core/http/HttpRequestTestSupport.java
    - [staticなフィールドに、インスタンスメソッドで値を代入している箇所の警告](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR326)
        - ロジックの修正となってしまうため、サプレスとしました。
        - 複数あり
    - [原型の使用の警告をサプレス](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR338)
        - 複数あり
    - [使用していないローカル引数を削除、deprecatedなクラスの使用をサプレス](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR363)
        - ListWrapperの処理を見る限り副作用はなさそうでしたが、念のため処理自体は残しています。
    - [presized-arrayによる配列化を修正](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR991)

- src/test/java/nablarch/test/core/http/AbstractHttpRequestTestTemplateTest.java
    - [不要なセミコロンを削除](https://github.com/nablarch/nablarch-testing/pull/65/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR991)
