### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/test/core/file/TestDataConverter.java
+++ b/src/main/java/nablarch/test/core/file/TestDataConverter.java
@@ -4,6 +4,7 @@ import java.nio.charset.Charset;
 
 import nablarch.core.dataformat.DataRecord;
 import nablarch.core.dataformat.LayoutDefinition;
+import nablarch.core.util.annotation.Published;
 
 /**
  * テストデータコンバータ<br>
@@ -12,6 +13,7 @@ import nablarch.core.dataformat.LayoutDefinition;
  * 
  * @author TIS
  */
+@Published
 public interface TestDataConverter {
     
     /**


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/LATEST/doc/development_tools/testing_framework/guide/development_guide/06_TestFWGuide/03_Tips.html#how-to-convert-test-data)には`TestDataConverter`の実装例が記載されているにもかかわらず、公開APIとなっていなかったため、プログラマ向けの公開APIとしました。