### PR TITLE
JakartaEE10対応で、JavaEE由来の表現を修正

### DIFF
--- a/src/main/java/nablarch/test/event/TestEventDispatcher.java
+++ b/src/main/java/nablarch/test/event/TestEventDispatcher.java
@@ -62,8 +62,8 @@ public abstract class TestEventDispatcher {
      * （{@link #checkErrorInStaticInitializer()}）。
      * </p>
      *
-     * @see <a href="https://docs.oracle.com/javase/specs/jls/se6/html/execution.html#12.4.2">
-     *      Java Language Specification Third Edition 12.4.2 Detailed Initialization Procedure</a>
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-12.html#jls-12.4.2">
+     *      The Java® Language Specification Java SE 17 Edition 12.4.2. Detailed Initialization Procedure</a>
      */
     private static void initializeDefaultRepository() {
         try {

--- a/src/main/java/nablarch/test/event/TestEventDispatcher.java
+++ b/src/main/java/nablarch/test/event/TestEventDispatcher.java
@@ -62,7 +62,7 @@ public abstract class TestEventDispatcher {
      * （{@link #checkErrorInStaticInitializer()}）。
      * </p>
      *
-     * @see <a href="http://java.sun.com/docs/books/jls/third_edition/html/execution.html#12.4.2">
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se6/html/execution.html#12.4.2">
      *      Java Language Specification Third Edition 12.4.2 Detailed Initialization Procedure</a>
      */
     private static void initializeDefaultRepository() {

--- a/src/test/java/nablarch/test/tool/sanitizingcheck/JspParserTest.java
+++ b/src/test/java/nablarch/test/tool/sanitizingcheck/JspParserTest.java
@@ -58,7 +58,7 @@ public class JspParserTest {
             Tag tag = tags.get(1);
             assertThat(tag.getType(), is(TagType.DIRECTIVE));
             assertThat(tag.getPosition(), is(1));
-            assertThat(tag.getCloseTagPosition(), is(64));
+            assertThat(tag.getCloseTagPosition(), is(48));
             assertThat(tag.getLineNo(), is(2));
             assertThat(tag.isSuppressJspCheck(), is(false));
             Directive directive = (Directive) tag;
@@ -69,13 +69,13 @@ public class JspParserTest {
             assertThat(attributes.get(0).getName(), is("prefix"));
             assertThat(attributes.get(0).getValue(), is("\"c\""));
             assertThat(attributes.get(1).getName(), is("uri"));
-            assertThat(attributes.get(1).getValue(), is("\"http://java.sun.com/jsp/jstl/core\""));
+            assertThat(attributes.get(1).getValue(), is("\"jakarta.tags.core\""));
         }
         みっつめ: {
             Tag tag = tags.get(2);
             assertThat(tag.getType(), is(TagType.DIRECTIVE));
-            assertThat(tag.getPosition(), is(66));
-            assertThat(tag.getCloseTagPosition(), is(51));
+            assertThat(tag.getPosition(), is(50));
+            assertThat(tag.getCloseTagPosition(), is(35));
             assertThat(tag.getLineNo(), is(2));
             assertThat(tag.isSuppressJspCheck(), is(false));
             Directive directive = (Directive) tag;
@@ -85,7 +85,7 @@ public class JspParserTest {
             assertThat(attributes.get(0).getName(), is("prefix"));
             assertThat(attributes.get(0).getValue(), is("\"f\""));
             assertThat(attributes.get(1).getName(), is("uri"));
-            assertThat(attributes.get(1).getValue(), is("\"http://java.sun.com/jsp/jstl/functions\""));
+            assertThat(attributes.get(1).getValue(), is("\"jakarta.tags.functions\""));
         }
 
         // 複数行にまたがって記述されているディレクティブ

--- a/src/test/java/nablarch/test/tool/sanitizingcheck/data/MultiTag.jsp
+++ b/src/test/java/nablarch/test/tool/sanitizingcheck/data/MultiTag.jsp
@@ -14,7 +14,7 @@
   <n:button uri="hoge" name="${userName}" />
   ${user.Name}
 </n:form>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <c:if test="true">
   <!-- <n:set value="hoge" var="fuga" />-->
 </c:if>

--- a/src/test/java/nablarch/test/tool/sanitizingcheck/data/directive.jsp
+++ b/src/test/java/nablarch/test/tool/sanitizingcheck/data/directive.jsp
@@ -1,6 +1,6 @@
 <%@ page import="java.util.*" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %> <%@ taglib prefix="f"
-    uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %> <%@ taglib prefix="f"
+    uri="jakarta.tags.functions" %>
 <%-- suppress jsp check:この次の行はチェック対象外 --%>
  <%@ page contentType="text/html; charset=utf-8"
     pageEncoding="utf-8"

--- a/src/test/java/nablarch/test/tool/sanitizingcheck/data/taglib.jsp
+++ b/src/test/java/nablarch/test/tool/sanitizingcheck/data/taglib.jsp
@@ -1,5 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="f" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="f" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="n" uri="http://tis.co.jp/nablarch" %>
 
 <c:set property="fuga" />

--- a/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
+++ b/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jsch/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html>
   <head>
     <title>Greeting Service</title>

--- a/src/test/resources/nablarch/fw/web/servlet/docroot/WEB-INF/web.xml
+++ b/src/test/resources/nablarch/fw/web/servlet/docroot/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-   version="2.5">
+   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+   version="6.0">
 </web-app>


### PR DESCRIPTION
以下の修正を実施
- タグファイルで参照しているuriパラメータの修正 (4fd5b3f6fb3d9583d07be9b8664be31c53f9670d) [（参考: c）](https://jakarta.ee/specifications/tags/3.0/tagdocs/c/tld-summary) [（参考: f）](https://jakarta.ee/specifications/tags/3.0/tagdocs/fn/tld-summary)
  - `JspPerserTest.java` は、directive.jspの修正によりテストが失敗するようになったので、併せて修正
    - このテストでは、修正した`directive.jsp`をパースした結果をテストしている。
    - 修正したテストは、JSPファイル中での「`taglib`ディレクティブの開始位置（`tag.getPosition`）」「`taglib`ディレクティブの終了位置（`tag.getCloseTagPosition`）」、「`taglib`ディレクティブの`uri`属性の値（`attributes.get(1).getValue()`）」である。
    - `uri`パラメータの値を変更したことで、ディレクティブの開始位置・終了位置・属性の値が変更となったため、テストを修正した。
  - `jstl_test.jsp` については、https://github.com/nablarch/nablarch-testing-jetty12/pull/7#issue-2356263468 と同じ対応を実施
- デプロイメント記述子をJakarta Servlet 6.0向けの記載に変更 (e91aefbff6153fb9f173f2d6f78edec84a103b6d)
  -  [Jakarta Servletの仕様](https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#rules-for-processing-the-deployment-descriptor)に従い修正を実施
  - `schemaLocation`は参考情報であるものの、修正前もウェブ上の実際の場所を記述する記載となっていたこと、および[参考記事](https://qiita.com/opengl-8080/items/7a2ddecdcdaeea229ae7)を踏まえ、Version6.0のXSDファイルの場所を記載した。
- Javadoc上のリンクが古いのを修正 (1eac70c3070b44c1f696371c262ae5800a1b783b)
  - 正しくリダイレクトされないため、正しいリンクに修正

以下については、当初修正予定だったものの実施しない判断とした。
- `http://java.sun.com/JSP/Page` を含むファイルの修正
  - 対象ファイルは以下2件。
    - `src/test/java/nablarch/test/tool/sanitizingcheck/all.jsp`
    - `src/test/java/nablarch/test/tool/sanitizingcheck/allDefault.jsp`
  - `java.sun.com`の表現を含むためJavaEE由来の文言と想定していたが、[Jakarta Server Pages 3.1仕様](https://jakarta.ee/ja/specifications/pages/3.1/jakarta-server-pages-spec-3.1.pdf)  6.3.1. Namespaces, Standard Actions, and Tag Libraries には以下の記載があり、JakartaEE10においてもそのままでよいと判断できる。
    - Though the prefix “jsp” is used throughout this specification, it is the namespace http://java.sun.com/JSP/Page and not the prefix “jsp” that identifies the JSP standard actions.

