### PR TITLE
org.eclipse.jdt.core.compiler:ecjへの依存の削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,6 @@
     <relativePath/>
   </parent>
   
-  <properties>
-    <ecj.version>4.6.1</ecj.version>
-  </properties>
-  
   <dependencies>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
@@ -156,12 +152,6 @@
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
       <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
-      <artifactId>ecj</artifactId>
-      <version>${ecj.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
nablarch-testingを依存定義している他のリポジトリでは、元のバージョンをexclusionで除外しつつ、 独自のバージョンで`org.eclipse.jdt.core.compiler:ecj`に依存している。
`ecj`の新旧が混在している状況なので、削除する。